### PR TITLE
Profile Selection Args

### DIFF
--- a/ilab-client
+++ b/ilab-client
@@ -13,8 +13,9 @@ ilab_bin=/opt/app-root/bin/ilab
 
 workflow="train"
 nnodes=1
-train_profile="L40_x4"
-#train_profile="l40s_x4"
+profile_name="L40_x4"
+profile_vendor="nvidia"
+profile_path="/opt/app-root/src/.local/share/instructlab/internal/system_profiles"
 train_model_path="/opt/app-root/src/.cache/instructlab/models/"
 train_phased_mt_bench_judge="/opt/app-root/src/.cache/instructlab/models/prometheus-8x7b-v2-0"
 train_phased_phase1_data="/opt/app-root/src/jul19-knowledge-26k.jsonl"
@@ -53,7 +54,8 @@ longopts+=",sdg-num-cpus:"
 longopts+=",sdg-batch-size:"
 longopts+=",sdg-model:"
 longopts+=",sdg-gpus:"
-longopts+=",train-profile:"
+longopts+=",profile-name:"
+longopts+=",profile-vendor:"
 longopts+=",train-model-path:"
 longopts+=",train-phased-mt-bench-judge:"
 longopts+=",train-phased-phase1-data:"
@@ -93,10 +95,15 @@ while true; do
             sdg_batch_size=" --batch-size $val"
             ;;
 
-    # The following options are for training
-        --train-profile)
-            train_profile=$val
+    # The following are used for ilab profile settings
+        --profile-name)
+            profile_name=$val
             ;;
+        --profile-vendor)
+            profile_vendor=$val
+            ;;
+
+    # The following options are for training
         --train-model-path)
             train_model_path=$val
             ;;
@@ -142,7 +149,16 @@ done
 # A100_H100_x2 A100_H100_x4 A100_H100_x8 L40_x4 L40_x8 L4_x8 train_a100x4x8
 #ilab config init --non-interactive --train-profile /usr/share/instructlab/training/profiles/$train_profile.yaml
 #ilab config init --non-interactive --profile /usr/share/instructlab/profiles/nvidia/l40s/$train_profile.yaml
-$ilab_bin config init --non-interactive
+
+full_profile_arg=""
+if [ $ilab_version_1 -ge 19 ]; then # RHELAI 1.3 and above
+    full_profile_arg="--profile $profile_path/$profile_vendor/$profile_name.yaml"
+else # RHELAI 1.2 and below
+    profile_path="/opt/app-root/src/.local/share/instructlab/internal/train_configuration/profiles"
+    full_profile_arg="--train-profile $profile_path/$profile_name.yaml"
+fi
+
+ilab config init $full_profile_arg
 
 $ilab_bin config show >ilab-config-show.yaml
 

--- a/multiplex.json
+++ b/multiplex.json
@@ -7,7 +7,7 @@
       "args" : [
         "sdg-model",
         "train-model-path",
-        "train-profile",
+        "profile-name",
         "train-phased-phase1-data",
         "train-phased-phase2-data",
         "train-phased-mt-bench-judge"
@@ -33,6 +33,11 @@
       "description" : "what type of work to do",
       "args" : [ "workflow" ],
       "vals" : "train|sdg"
+    },
+    "gpu_vendor": {
+      "description": "A set of supported GPU vendors",
+      "args": [ "profile-vendor" ],
+      "vals": "amd|nvidia"
     }
   }
 }


### PR DESCRIPTION
This PR adds arguments to set the profile of the ilab client.  Auto detection is not perfect and has lead to under utilization of compute resources.  Allowing a command line argument to specify what profile to use avoids this situation.

This renames 1 parameter and adds another

- `train-profile` is renamed to `profile-name` as the profile determines more than just training settings
- `profile-vendor` is used with the intent to support multiple instructlab images (for example, AMD)

Compatibility for RHELAI 1.2 and below is included.