### PR TITLE
fix: remove --from-file from run example

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Scripts and configuration to run [InstructLab](https://instructlab.ai/) training workloads within the [crucible](https://github.com/perftool-incubator/crucible) performance testing framework.
 
-See `run-ilab.json` for example usage with `crucible run --from-file run-ilab.json`.
+See `run-ilab.json` for example usage with `crucible run run-ilab.json`.
 
 ## Key Files
 


### PR DESCRIPTION
## Summary

Remove the legacy `--from-file` parameter from the README run example.

Ref: perftool-incubator/crucible-examples#62

🤖 Generated with [Claude Code](https://claude.com/claude-code)